### PR TITLE
Recover from server disconnection by timeout

### DIFF
--- a/lib/Predis/Connection/AbstractConnection.php
+++ b/lib/Predis/Connection/AbstractConnection.php
@@ -24,7 +24,7 @@ use Predis\Protocol\ProtocolException;
  */
 abstract class AbstractConnection implements SingleConnectionInterface
 {
-    private $resource;
+    protected $resource;
     private $cachedId;
 
     protected $parameters;
@@ -165,7 +165,7 @@ abstract class AbstractConnection implements SingleConnectionInterface
      */
     public function getResource()
     {
-        if (isset($this->resource)) {
+        if ($this->isConnected()) {
             return $this->resource;
         }
 

--- a/lib/Predis/Connection/StreamConnection.php
+++ b/lib/Predis/Connection/StreamConnection.php
@@ -127,6 +127,14 @@ class StreamConnection extends AbstractConnection
     /**
      * {@inheritdoc}
      */
+    public function isConnected()
+    {
+        return isset($this->resource) && !feof($this->resource);    
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function connect()
     {
         if (parent::connect() && $this->initCommands) {

--- a/tests/Predis/Connection/StreamConnectionTest.php
+++ b/tests/Predis/Connection/StreamConnectionTest.php
@@ -99,6 +99,25 @@ class StreamConnectionTest extends PredisConnectionTestCase
         $connection->read();
     }
 
+    /**
+     * @group connected
+     */
+    public function testConnectionRecoveryAfterServerDisconnectionByTimeout()
+    {
+        $connection = $this->getConnection($profile);
+        $connection->addConnectCommand(
+            $profile->createCommand('config', array('set', 'timeout', '1'))
+        );
+        
+        $connection->writeRequest($profile->createCommand('ping'));
+        $this->assertEquals('PONG', $connection->read());
+        
+        $this->sleep(2);
+
+        $connection->writeRequest($profile->createCommand('ping'));
+        $this->assertEquals('PONG', $connection->read());
+    }
+
     // ******************************************************************** //
     // ---- HELPER METHODS ------------------------------------------------ //
     // ******************************************************************** //


### PR DESCRIPTION
If Redis Server has a connection timeout set, a Predis client using the stream adapter may be left with a useless (closed) resource when Redis drops the conection per timeout.
When that happens, the user receives a Predis\Connection\ConnectionException "Error while reading line from the server.", but that one is not recoverable from outside the lib, as the connect method will return the closed resource.

More details on this patch and why it was implemented that way can be found on commit messages.

When I've set the timeout to "1" on my server, other tests started failing (see below) and are also fixed by this patch.

**Tests failing with timeout set to "1" (All of them now pass!):**
Predis\Command\KeyExpireAtTest::testCanExpireKeys
Predis\Command\KeyExpireTest::testCanExpireKeys
Predis\Command\KeyExpireTest::testConsistencyWithTTL
Predis\Command\KeyPreciseExpireAtTest::testCanExpireKeys
Predis\Command\StringSetExpireTest::testKeyExpiresAfterTTL
