### PR TITLE
Apply read_write_timeout to Unix socket connections.

### DIFF
--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -123,6 +123,14 @@ class StreamConnection extends AbstractConnection
             $this->onConnectionError(trim($errstr), $errno);
         }
 
+        if (isset($parameters->read_write_timeout)) {
+            $rwtimeout = (float) $parameters->read_write_timeout;
+            $rwtimeout = $rwtimeout > 0 ? $rwtimeout : -1;
+            $timeoutSeconds  = floor($rwtimeout);
+            $timeoutUSeconds = ($rwtimeout - $timeoutSeconds) * 1000000;
+            stream_set_timeout($resource, $timeoutSeconds, $timeoutUSeconds);
+        }
+
         return $resource;
     }
 


### PR DESCRIPTION
I noticed my Predis connections timing out on long running Unix socket connections even with read_write_timeout set to 0. It looks like it only gets set when using TCP connections.

I copied the code from the tcpStreamInitializer() method right above it which is not necessarily nice but gets the job done. Please bear with me if I missed something since this is my first contribution on GitHub ever. :)