### PR TITLE
PubSub doesn't work on HHVM because of stream_set_timeout inconsistency

### DIFF
--- a/lib/Predis/Connection/StreamConnection.php
+++ b/lib/Predis/Connection/StreamConnection.php
@@ -86,7 +86,11 @@ class StreamConnection extends AbstractConnection
 
         if (isset($parameters->read_write_timeout)) {
             $rwtimeout = $parameters->read_write_timeout;
-            $rwtimeout = $rwtimeout > 0 ? $rwtimeout : -1;
+            if ($rwtimeout == -2) {
+                $rwtimeout = 0;
+            } else if ($rwtimeout <= 0) {
+                $rwtimeout = -1;
+            }
             $timeoutSeconds  = floor($rwtimeout);
             $timeoutUSeconds = ($rwtimeout - $timeoutSeconds) * 1000000;
             stream_set_timeout($resource, $timeoutSeconds, $timeoutUSeconds);


### PR DESCRIPTION
hey @nrk I know this is a shitty hack, but I figured I'd share it so that you're at least aware of this.

Zend PHP uses -1 for stream_set_timeout to set it to block forever.
HHVM uses 0 for stream_set_timeout to set it to block forever.

unfortunatly you've made it so that  read_write_timeout=0 is converted to read_write_timeout=-1 so there's noway to make this work on HHVM.

I'll report this for HHVM and see if they can fix it, and in the meantime will use this patch for my personal use, you probably don't want something this ugly in your repo ... 
