### PR TITLE
Emit socket error if ipredis connection has been lost/reset.

### DIFF
--- a/lib/Predis/Connection/PhpiredisConnection.php
+++ b/lib/Predis/Connection/PhpiredisConnection.php
@@ -358,7 +358,7 @@ class PhpiredisConnection extends AbstractConnection
         $reader = $this->reader;
 
         while (($state = phpiredis_reader_get_state($reader)) === PHPIREDIS_READER_STATE_INCOMPLETE) {
-            if (@socket_recv($socket, $buffer, 4096, 0) === false || $buffer === '') {
+            if (@socket_recv($socket, $buffer, 4096, 0) === false || $buffer === '' || $buffer === null) {
                 $this->emitSocketError();
             }
 


### PR DESCRIPTION
The current code is checking for a failure (return false) or an empty buffer string, however neither of these will be the case if the connection has been reset or has errored. According to the docs for socket_recv, $buffer will be set to null if the connection is reset or their is no data. As currently null is not allowed for, we enter an infinite loop, to prevent this I've added null to the things we check before we emit a socket error. This prevents the infinite loop and correctly results in an Exception if the connection is lost/reset.

I've made this change against the 0.8 branch as that is the version I am using, however the issue still exists with later 1.0 releases.