### PR TITLE
Don't check for __invoke on non-objects

### DIFF
--- a/src/Configuration/Options.php
+++ b/src/Configuration/Options.php
@@ -100,7 +100,7 @@ class Options implements OptionsInterface
             $value = $this->input[$option];
             unset($this->input[$option]);
 
-            if (method_exists($value, '__invoke')) {
+            if (is_object($value) && method_exists($value, '__invoke')) {
                 $value = $value($this, $option);
             }
 


### PR DESCRIPTION
Fixes #257

Couldn't think of a good way to test autoloading within PHPUnit other than registering an actual autoloader, or putting a never-loaded class somewhere the existing autoloader can get to it (and asserting on the value of `class_exists(X, false)`). That seemed a bit messy, so I've left a regression test out (all code paths still covered by existing tests), but could do one if you want.