### PR TITLE
bugfix, when reuse persistent connection with different database on one redis

### DIFF
--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -89,6 +89,11 @@ class StreamConnection extends AbstractConnection
         if (isset($parameters->persistent) && (bool) $parameters->persistent) {
             $flags |= STREAM_CLIENT_PERSISTENT;
             $uri .= strpos($path = $parameters->path, '/') === 0 ? $path : "/$path";
+
+            $database = isset($parameters->database) ? $parameters->database : 0;
+            if ($database) {
+                $uri .= '?database='.$database;
+            }
         }
 
         $resource = @stream_socket_client($uri, $errno, $errstr, (float) $parameters->timeout, $flags);


### PR DESCRIPTION
```php
<?php
$redis1 = new \Predis\Client([
    'scheme' => 'tcp',
    'host' => '127.0.0.1',
    'persistent' => true,
    'database' => 1,
]);

// same redis server with different database
$redis2 = new \Predis\Client([
    'scheme' => 'tcp',
    'host' => '127.0.0.1',
    'persistent' => true,
    'database' => 2,
]);

// init command: SELECT 2
$redis2->ping();

// init command: SELECT 1
$redis1->ping();

// $redis1 and $redis2 use one stream resource
// expect set "foo" in database 2, but actually in database 1
$redis2->set('foo', 'bar');
var_dump($redis2->get('foo'));

// create new connection like $redis2
$redis3 = new \Predis\Client([
    'scheme' => 'tcp',
    'host' => '127.0.0.1',
    'persistent' => true,
    'database' => 2,
]);

// return NULL
var_dump($redis3->get('foo'));
```