### PR TITLE
Example of a multibyte bug test case

### DIFF
--- a/src/Connection/CompositeStreamConnection.php
+++ b/src/Connection/CompositeStreamConnection.php
@@ -73,7 +73,7 @@ class CompositeStreamConnection extends StreamConnection implements CompositeCon
             }
 
             $value .= $chunk;
-        } while (($length -= strlen($chunk)) > 0);
+        } while (($length -= mb_strlen($chunk, '8bit')) > 0);
 
         return $value;
     }

--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -183,7 +183,7 @@ class StreamConnection extends AbstractConnection
     {
         $socket = $this->getResource();
 
-        while (($length = strlen($buffer)) > 0) {
+        while (($length = mb_strlen($buffer, '8bit')) > 0) {
             $written = @fwrite($socket, $buffer);
 
             if ($length === $written) {
@@ -235,7 +235,7 @@ class StreamConnection extends AbstractConnection
                     }
 
                     $bulkData .= $chunk;
-                    $bytesLeft = $size - strlen($bulkData);
+                    $bytesLeft = $size - mb_strlen($bulkData, '8bit');
                 } while ($bytesLeft > 0);
 
                 return substr($bulkData, 0, -2);
@@ -283,7 +283,7 @@ class StreamConnection extends AbstractConnection
 
         for ($i = 0, $reqlen--; $i < $reqlen; ++$i) {
             $argument = $arguments[$i];
-            $arglen = strlen($argument);
+            $arglen = mb_strlen($argument, '8bit');
             $buffer .= "\${$arglen}\r\n{$argument}\r\n";
         }
 

--- a/src/Protocol/Text/RequestSerializer.php
+++ b/src/Protocol/Text/RequestSerializer.php
@@ -38,7 +38,7 @@ class RequestSerializer implements RequestSerializerInterface
 
         for ($i = 0, $reqlen--; $i < $reqlen; ++$i) {
             $argument = $arguments[$i];
-            $arglen = strlen($argument);
+            $arglen = mb_strlen($argument, '8bit');
             $buffer .= "\${$arglen}\r\n{$argument}\r\n";
         }
 

--- a/tests/PHPUnit/PredisConnectionTestCase.php
+++ b/tests/PHPUnit/PredisConnectionTestCase.php
@@ -367,6 +367,20 @@ abstract class PredisConnectionTestCase extends PredisTestCase
     /**
      * @group connected
      */
+    public function testReadsMultiByteResponses()
+    {
+        $profile = $this->getCurrentProfile();
+        $connection = $this->createConnection(true);
+
+        $connection->executeCommand($profile->createCommand('set', array('foo', '€')));
+
+        $connection->writeRequest($profile->createCommand('get', array('foo')));
+        $this->assertSame('€', $connection->read());
+    }
+    
+    /**
+     * @group connected
+     */
     public function testReadsIntegerResponses()
     {
         $profile = $this->getCurrentProfile();


### PR DESCRIPTION
Primarily adding this as a sample bug report, along with a semi-fix.  I think that probably some installation's won't have the mb_* functions, so perhaps it shoud be wrapped?