### PR TITLE
Cleanup unused variables in response status.

### DIFF
--- a/src/Response/Status.php
+++ b/src/Response/Status.php
@@ -18,9 +18,19 @@ namespace Predis\Response;
  */
 class Status implements ResponseInterface
 {
-    private static $OK;
-    private static $QUEUED;
+    /**
+     * @var string
+     */
+    const OK = 'OK';
 
+    /**
+     * @var string
+     */
+    const QUEUED = 'QUEUED';
+
+    /**
+     * @var string
+     */
     private $payload;
 
     /**
@@ -64,8 +74,8 @@ class Status implements ResponseInterface
     public static function get($payload)
     {
         switch ($payload) {
-            case 'OK':
-            case 'QUEUED':
+            case self::OK:
+            case self::QUEUED:
                 if (isset(self::$$payload)) {
                     return self::$$payload;
                 }


### PR DESCRIPTION
Remove unused private variables in response status
class, and replace magic strings in switch cases
to use constants.