### PR TITLE
fix tests, list of allowed commands have changed (redis 3.0.6)

### DIFF
--- a/tests/Predis/Command/PubSubSubscribeByPatternTest.php
+++ b/tests/Predis/Command/PubSubSubscribeByPatternTest.php
@@ -145,7 +145,7 @@ class PubSubSubscribeByPatternTest extends PredisCommandTestCase
     /**
      * @group connected
      * @expectedException \Predis\Response\ServerException
-     * @expectedExceptionMessage ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / QUIT allowed in this context
+     * @expectedExceptionMessageRegExp /ERR only .* allowed in this context/
      */
     public function testCannotSendOtherCommandsAfterPsubscribe()
     {

--- a/tests/Predis/Command/PubSubSubscribeTest.php
+++ b/tests/Predis/Command/PubSubSubscribeTest.php
@@ -145,7 +145,7 @@ class PubSubSubscribeTest extends PredisCommandTestCase
     /**
      * @group connected
      * @expectedException \Predis\Response\ServerException
-     * @expectedExceptionMessage ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / QUIT allowed in this context
+     * @expectedExceptionMessageRegExp /ERR only .* allowed in this context/
      */
     public function testCannotSendOtherCommandsAfterSubscribe()
     {


### PR DESCRIPTION
Detected in Fedora QA, broken since redis 3.0.6

See https://apps.fedoraproject.org/koschei/package/php-nrk-Predis

     There were 2 failures:
     1) Predis\Command\PubSubSubscribeByPatternTest::testCannotSendOtherCommandsAfterPsubscribe
     Failed asserting that exception message 'ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context' contains 'ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / QUIT allowed in this context'.
     2) Predis\Command\PubSubSubscribeTest::testCannotSendOtherCommandsAfterSubscribe
     Failed asserting that exception message 'ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context' contains 'ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / QUIT allowed in this context'.
     FAILURES!
