### PR TITLE
When using redis cluster, add option to cache 'CLUSTER SLOTS' response

### DIFF
--- a/src/Connection/Aggregate/RedisCluster.php
+++ b/src/Connection/Aggregate/RedisCluster.php
@@ -55,6 +55,8 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
 	private $cacheSlotMapDirectory;
 	private $cacheSlotMapFile;
 
+	const CACHED_FILENAME_PREFIX = 'predis-cached-slots';
+
     /**
      * @param FactoryInterface  $connections Optional connection factory.
      * @param StrategyInterface $strategy    Optional cluster strategy.
@@ -600,7 +602,7 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
 	protected function getCacheSlotMapFile()
 	{
 		if ($this->cacheSlotMapDirectory && !$this->cacheSlotMapFile) {
-			$this->cacheSlotMapFile = $this->cacheSlotMapDirectory . '/' . 'redis-cached-slots-' . md5(serialize($this->pool));
+			$this->cacheSlotMapFile = $this->cacheSlotMapDirectory . '/' . static::CACHED_FILENAME_PREFIX . '-' . md5(serialize($this->pool));
 		}
 
 		return $this->cacheSlotMapFile;

--- a/src/Connection/Aggregate/RedisCluster.php
+++ b/src/Connection/Aggregate/RedisCluster.php
@@ -164,7 +164,9 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
         $this->slotsMap = array();
 
 	    // load cache if set
-	    $this->loadCacheSlotsMapFile();
+	    if ($this->cacheSlotMapDirectory) {
+		    $this->loadCacheSlotsMapFile();
+	    }
 
 	    // load slots passes into connections
         foreach ($this->pool as $connectionID => $connection) {

--- a/src/Connection/Aggregate/RedisCluster.php
+++ b/src/Connection/Aggregate/RedisCluster.php
@@ -11,6 +11,7 @@
 
 namespace Predis\Connection\Aggregate;
 
+use Predis\ClientException;
 use Predis\Cluster\RedisStrategy as RedisClusterStrategy;
 use Predis\Cluster\StrategyInterface;
 use Predis\Command\CommandInterface;
@@ -51,6 +52,8 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
     private $slotsMap;
     private $strategy;
     private $connections;
+	private $cacheSlotMapDirectory;
+	private $cacheSlotMapFile;
 
     /**
      * @param FactoryInterface  $connections Optional connection factory.
@@ -158,6 +161,10 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
     {
         $this->slotsMap = array();
 
+	    // load cache if set
+	    $this->loadCacheSlotsMapFile();
+
+	    // load slots passes into connections
         foreach ($this->pool as $connectionID => $connection) {
             $parameters = $connection->getParameters();
 
@@ -188,17 +195,28 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
         $command = RawCommand::create('CLUSTER', 'SLOTS');
         $response = $connection->executeCommand($command);
 
+	    $cachedSlotMap = '';
+
         foreach ($response as $slots) {
             // We only support master servers for now, so we ignore subsequent
             // elements in the $slots array identifying slaves.
             list($start, $end, $master) = $slots;
 
-            if ($master[0] === '') {
-                $this->setSlots($start, $end, (string) $connection);
-            } else {
-                $this->setSlots($start, $end, "{$master[0]}:{$master[1]}");
-            }
+	        if ($master[0] === '') {
+		        $master = (string) $connection;
+	        }
+	        else {
+		        $master = $master[0] . ':' . $master[1];
+	        }
+
+	        $this->setSlots($start, $end, $master);
+	        $cachedSlotMap .= $start . '-' . $end . '-' . $master . PHP_EOL;
         }
+
+	    // save the results of the slot map to a cache file
+	    if ($this->cacheSlotMapDirectory) {
+		    file_put_contents($this->getCacheSlotMapFile(), $cachedSlotMap, LOCK_EX);
+	    }
 
         return $this->slotsMap;
     }
@@ -550,4 +568,58 @@ class RedisCluster implements ClusterInterface, \IteratorAggregate, \Countable
             $parameters ?: array()
         );
     }
+
+	/**
+	 * Turn on caching of CLUSTER SLOTS and choose a directory to save the
+	 * cache file to.  Turning on caching will help save a CLUSTER SLOTS call
+	 * on new PHP processes.
+	 *
+	 * Ensure the directory is writable.  On linux, /dev/shm is a good option
+	 * to reduce disk i/o.
+	 *
+	 * @param string $directory
+	 * @throws ClientException
+	 */
+	public function setCacheSlotMapDirectory($directory)
+	{
+		if (!is_writable($directory))
+			throw new ClientException('directory \'' . $directory . '\' is not writable');
+
+		$this->cacheSlotMapDirectory = $directory;
+	}
+
+	/**
+	 * Gets the name of the file used to cache the CLUSTER SLOTS request.  The
+	 * name is hashed off the connection pool to allow cached data for each
+	 * unique pool being connected to.
+	 *
+	 * This method will return null if setCacheSlotMapDirectory() not set
+	 *
+	 * @return string|null
+	 */
+	protected function getCacheSlotMapFile()
+	{
+		if ($this->cacheSlotMapDirectory && !$this->cacheSlotMapFile) {
+			$this->cacheSlotMapFile = $this->cacheSlotMapDirectory . '/' . 'redis-cached-slots-' . md5(serialize($this->pool));
+		}
+
+		return $this->cacheSlotMapFile;
+	}
+
+	/**
+	 * Try to load a cached CLUSTER SLOTS response
+	 */
+	protected function loadCacheSlotsMapFile()
+	{
+		if ($this->cacheSlotMapDirectory && is_file($this->getCacheSlotMapFile())) {
+			$cached_slots = file($this->getCacheSlotMapFile());
+
+			if (is_array($cached_slots)) {
+				foreach ($cached_slots as $cached_slot) {
+					$slots = explode('-', $cached_slot);
+					$this->setSlots($slots[0], $slots[1], $slots[2]);
+				}
+			}
+		}
+	}
 }

--- a/tests/Predis/Connection/Aggregate/RedisClusterTest.php
+++ b/tests/Predis/Connection/Aggregate/RedisClusterTest.php
@@ -779,7 +779,7 @@ class RedisClusterTest extends PredisTestCase
 			->will($this->returnValue($connection2));
 
 		// mock loadCacheSlotsMapFile to point all hashes to the second host
-		$cluster = $this->getMock('Predis\Connection\Aggregate\RedisCluster', array('loadCacheSlotsMapFile'), [$factory]);
+		$cluster = $this->getMock('Predis\Connection\Aggregate\RedisCluster', array('loadCacheSlotsMapFile'), array($factory));
 		$cluster->expects($this->atLeastOnce())
 			->method('loadCacheSlotsMapFile')
 			->will($this->returnCallback(function () use ($cluster) {$cluster->setSlots(0, 16383, '127.0.0.1:6380');} ));
@@ -837,7 +837,7 @@ class RedisClusterTest extends PredisTestCase
 			->with(array('host' => '127.0.0.1', 'port' => '6380'))
 			->will($this->returnValue($connection2));
 
-		$cluster = $this->getMock('Predis\Connection\Aggregate\RedisCluster', array('getCacheSlotMapFile'), [$factory]);
+		$cluster = $this->getMock('Predis\Connection\Aggregate\RedisCluster', array('getCacheSlotMapFile'), array($factory));
 		$cluster->expects($this->atLeastOnce())
 			->method('getCacheSlotMapFile')
 			->will($this->returnValue($cached_file));

--- a/tests/Predis/Connection/Aggregate/RedisClusterTest.php
+++ b/tests/Predis/Connection/Aggregate/RedisClusterTest.php
@@ -313,7 +313,7 @@ class RedisClusterTest extends PredisTestCase
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
 
         $cluster = new RedisCluster(new Connection\Factory());
-	    $cluster->add($connection1);
+        $cluster->add($connection1);
         $cluster->add($connection2);
 
         $cluster->setSlots(0, 2047, '127.0.0.1:6379');
@@ -742,7 +742,7 @@ class RedisClusterTest extends PredisTestCase
                 ->with(array('host' => '127.0.0.1', 'port' => '6380'))
                 ->will($this->returnValue($connection2));
 
-	    $cluster = new RedisCluster($factory);
+        $cluster = new RedisCluster($factory);
         $cluster->add($connection1);
 
         $this->assertSame('foobar', $cluster->executeCommand($cmdGET));

--- a/tests/Predis/Connection/Aggregate/RedisClusterTest.php
+++ b/tests/Predis/Connection/Aggregate/RedisClusterTest.php
@@ -779,7 +779,7 @@ class RedisClusterTest extends PredisTestCase
 			->will($this->returnValue($connection2));
 
 		// mock loadCacheSlotsMapFile to point all hashes to the second host
-		$cluster = $this->getMock('Predis\Connection\Aggregate\RedisCluster', ['loadCacheSlotsMapFile'], [$factory]);
+		$cluster = $this->getMock('Predis\Connection\Aggregate\RedisCluster', array('loadCacheSlotsMapFile'), [$factory]);
 		$cluster->expects($this->atLeastOnce())
 			->method('loadCacheSlotsMapFile')
 			->will($this->returnCallback(function () use ($cluster) {$cluster->setSlots(0, 16383, '127.0.0.1:6380');} ));
@@ -837,7 +837,7 @@ class RedisClusterTest extends PredisTestCase
 			->with(array('host' => '127.0.0.1', 'port' => '6380'))
 			->will($this->returnValue($connection2));
 
-		$cluster = $this->getMock('Predis\Connection\Aggregate\RedisCluster', ['getCacheSlotMapFile'], [$factory]);
+		$cluster = $this->getMock('Predis\Connection\Aggregate\RedisCluster', array('getCacheSlotMapFile'), [$factory]);
 		$cluster->expects($this->atLeastOnce())
 			->method('getCacheSlotMapFile')
 			->will($this->returnValue($cached_file));

--- a/tests/Predis/Connection/Aggregate/RedisClusterTest.php
+++ b/tests/Predis/Connection/Aggregate/RedisClusterTest.php
@@ -313,7 +313,7 @@ class RedisClusterTest extends PredisTestCase
         $connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
 
         $cluster = new RedisCluster(new Connection\Factory());
-        $cluster->add($connection1);
+	    $cluster->add($connection1);
         $cluster->add($connection2);
 
         $cluster->setSlots(0, 2047, '127.0.0.1:6379');
@@ -742,12 +742,133 @@ class RedisClusterTest extends PredisTestCase
                 ->with(array('host' => '127.0.0.1', 'port' => '6380'))
                 ->will($this->returnValue($connection2));
 
-        $cluster = new RedisCluster($factory);
+	    $cluster = new RedisCluster($factory);
         $cluster->add($connection1);
 
         $this->assertSame('foobar', $cluster->executeCommand($cmdGET));
         $this->assertSame(2, count($cluster));
     }
+
+	/**
+	 * @group disconnected
+	 */
+	public function testCacheAskSlotsMap()
+	{
+		$cmdGET = Command\RawCommand::create('GET', 'node:1001');
+
+		// setup host the cluster client connects to
+		$connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
+
+		// ensure no calls get sent to this host as the cached file directs to a different host
+		$connection1->expects($this->never())
+			->method('executeCommand');
+
+		// setup connection to the host that cached file redirects to
+		$connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
+
+		// ensure only one executeCommand ('GET', not 'CLUSTER CLIENT') sent to correct host
+		$connection2->expects($this->once())
+			->method('executeCommand')
+			->with($cmdGET)
+			->will($this->returnValue('foobar'));
+
+		$factory = $this->getMock('Predis\Connection\Factory');
+		$factory->expects($this->once())
+			->method('create')
+			->with(array('host' => '127.0.0.1', 'port' => '6380'))
+			->will($this->returnValue($connection2));
+
+		// mock loadCacheSlotsMapFile to point all hashes to the second host
+		$cluster = $this->getMock('Predis\Connection\Aggregate\RedisCluster', ['loadCacheSlotsMapFile'], [$factory]);
+		$cluster->expects($this->atLeastOnce())
+			->method('loadCacheSlotsMapFile')
+			->will($this->returnCallback(function () use ($cluster) {$cluster->setSlots(0, 16383, '127.0.0.1:6380');} ));
+
+
+		$cluster->useClusterSlots(true);
+		$cluster->setCacheSlotMapDirectory('/dev/shm');
+		$cluster->add($connection1);
+
+		$this->assertSame('foobar', $cluster->executeCommand($cmdGET));
+		$this->assertSame(2, count($cluster));
+	}
+
+	/**
+	 * @group disconnected
+	 */
+	public function testCacheAskSlotsMapCreateCacheFile()
+	{
+		// ensure the OS has a /tmp directory which is writable
+		if (!is_writable('/tmp'))
+			$this->markTestSkipped('directory \'/tmp\' does not exist or is not writable');
+
+		$cached_file = '/tmp/' . RedisCluster::CACHED_FILENAME_PREFIX . '-unittest';
+
+		// ensure the file does not exist before the test
+		if (is_file($cached_file))
+			unlink($cached_file);
+
+		$cmdGET = Command\RawCommand::create('GET', 'node:1001');
+		$rspMOVED = new Response\Error('MOVED 1970 127.0.0.1:6380');
+		$rspSlotsArray = array(
+			array(0   ,  8191, array('127.0.0.1', 6379)),
+			array(8192, 16383, array('127.0.0.1', 6380)),
+		);
+
+		$connection1 = $this->getMockConnection('tcp://127.0.0.1:6379');
+		$connection1->expects($this->once())
+			->method('executeCommand')
+			->with($cmdGET)
+			->will($this->returnValue($rspMOVED));
+
+		$connection2 = $this->getMockConnection('tcp://127.0.0.1:6380');
+		$connection2->expects($this->at(0))
+			->method('executeCommand')
+			->with($this->isRedisCommand('CLUSTER', array('SLOTS')))
+			->will($this->returnValue($rspSlotsArray));
+		$connection2->expects($this->at(2))
+			->method('executeCommand')
+			->with($cmdGET)
+			->will($this->returnValue('foobar'));
+
+		$factory = $this->getMock('Predis\Connection\Factory');
+		$factory->expects($this->once())
+			->method('create')
+			->with(array('host' => '127.0.0.1', 'port' => '6380'))
+			->will($this->returnValue($connection2));
+
+		$cluster = $this->getMock('Predis\Connection\Aggregate\RedisCluster', ['getCacheSlotMapFile'], [$factory]);
+		$cluster->expects($this->atLeastOnce())
+			->method('getCacheSlotMapFile')
+			->will($this->returnValue($cached_file));
+
+		$cluster->setCacheSlotMapDirectory('/tmp');
+		$cluster->add($connection1);
+
+		$this->assertSame('foobar', $cluster->executeCommand($cmdGET));
+		$this->assertSame(2, count($cluster));
+
+		// ensure the cached file was written to disk
+		$this->assertTrue(is_file($cached_file));
+
+		// ensure the cached file has a row for each slot returned from 'CLUSTER SLOTS'
+		$this->assertCount(count($rspSlotsArray), file($cached_file));
+
+		// clean up from test
+		if (is_file($cached_file))
+			unlink($cached_file);
+	}
+
+	/**
+	 * @group disconnected
+	 * @expectedException \Predis\ClientException
+	 * @expectedExceptionMessage is not writable
+	 */
+	public function testThrowsExceptionOnInvalidCacheDirectory()
+	{
+		$cluster = new RedisCluster(new Connection\Factory());
+		$cluster->setCacheSlotMapDirectory('/invalid/directory');
+	}
 
     /**
      * @group disconnected
@@ -795,7 +916,7 @@ class RedisClusterTest extends PredisTestCase
      *
      * @param mixed $parameters Optional parameters.
      *
-     * @return mixed
+     * @return \Predis\Connection\NodeConnectionInterface
      */
     protected function getMockConnection($parameters = null)
     {


### PR DESCRIPTION
This is an optimization to redis cluster using `useClusterSlots(true)`.

Currently on newly instantiated PHP processes, the first called redis command may result in two extra round trips to the redis cluster.  The first call could result in a `MOVE`.  We then make a call to the new cluster calling `CLUSTER SLOTS` to learn which hosts the slots are on.  The rest of the calls in this PHP process should be correct but on the next PHP spawn, we've forgotten the location of the slots.

This PR add a `setCacheSlotMapDirectory($directory)` method.  If set, predis will save the results of a `CLUSTER SLOTS` lookup and then load the results on newly created instances saving the two extra round trips on boot.

The PR includes unit tests for the new functionality.

I tried to match the existing coding style of predis.  Let me know if interested in the PR but would like to see some changes before merging the code upstream.