### PR TITLE
Master-Slave Replication - client side read-slave failover

### DIFF
--- a/src/Connection/Aggregate/MasterSlaveReplication.php
+++ b/src/Connection/Aggregate/MasterSlaveReplication.php
@@ -11,9 +11,12 @@
 
 namespace Predis\Connection\Aggregate;
 
+use InvalidArgumentException;
+use RuntimeException;
 use Predis\Command\CommandInterface;
 use Predis\Connection\NodeConnectionInterface;
 use Predis\Replication\ReplicationStrategy;
+use Predis\Connection\ConnectionException;
 
 /**
  * Aggregate connection handling replication of Redis nodes configured in a
@@ -43,7 +46,7 @@ class MasterSlaveReplication implements ReplicationInterface
     protected function check()
     {
         if (!isset($this->master) || !$this->slaves) {
-            throw new \RuntimeException('Replication needs one master and at least one slave.');
+            throw new RuntimeException('Replication needs one master and at least one slave.');
         }
     }
 
@@ -131,7 +134,7 @@ class MasterSlaveReplication implements ReplicationInterface
             return $this->slaves[$connectionId];
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -145,7 +148,7 @@ class MasterSlaveReplication implements ReplicationInterface
             $connection = $this->getConnectionById($connection);
         }
         if ($connection !== $this->master && !in_array($connection, $this->slaves, true)) {
-            throw new \InvalidArgumentException('Invalid connection or connection not found.');
+            throw new InvalidArgumentException('Invalid connection or connection not found.');
         }
 
         $this->current = $connection;
@@ -192,7 +195,8 @@ class MasterSlaveReplication implements ReplicationInterface
      */
     protected function pickSlave()
     {
-        return $this->slaves[array_rand($this->slaves)];
+        $slave = $this->slaves[array_rand($this->slaves)];
+        return $slave;
     }
 
     /**
@@ -251,7 +255,27 @@ class MasterSlaveReplication implements ReplicationInterface
      */
     public function executeCommand(CommandInterface $command)
     {
-        return $this->getConnection($command)->executeCommand($command);
+        $connection = $this->getConnection($command);
+        $result     = null;
+        try{
+            $result = $connection->executeCommand($command);
+        }
+        catch(ConnectionException $e){
+             //Only switch to other read-slave if current connection is not master and there is more than 1 read-slave available
+            if($connection != $this->master && count($this->slaves) > 1){
+                foreach($this->slaves as $slave){
+                    if($slave == $connection){
+                        unset($this->slaves[$slave->getParameters()->alias]);
+                    }
+                }
+                $this->current = null;
+                return $this->executeCommand($command);
+            }
+
+            // If no error handling was performed, this block should remain "transparent" (i.e. throw the exception without doing anything)
+            throw $e;
+        }
+        return $result;
     }
 
     /**

--- a/src/Connection/Aggregate/MasterSlaveReplication.php
+++ b/src/Connection/Aggregate/MasterSlaveReplication.php
@@ -11,8 +11,6 @@
 
 namespace Predis\Connection\Aggregate;
 
-use InvalidArgumentException;
-use RuntimeException;
 use Predis\Command\CommandInterface;
 use Predis\Connection\NodeConnectionInterface;
 use Predis\Replication\ReplicationStrategy;
@@ -46,7 +44,7 @@ class MasterSlaveReplication implements ReplicationInterface
     protected function check()
     {
         if (!isset($this->master) || !$this->slaves) {
-            throw new RuntimeException('Replication needs one master and at least one slave.');
+            throw new \RuntimeException('Replication needs one master and at least one slave.');
         }
     }
 
@@ -134,7 +132,7 @@ class MasterSlaveReplication implements ReplicationInterface
             return $this->slaves[$connectionId];
         }
 
-        return null;
+        return;
     }
 
     /**
@@ -148,7 +146,7 @@ class MasterSlaveReplication implements ReplicationInterface
             $connection = $this->getConnectionById($connection);
         }
         if ($connection !== $this->master && !in_array($connection, $this->slaves, true)) {
-            throw new InvalidArgumentException('Invalid connection or connection not found.');
+            throw new \InvalidArgumentException('Invalid connection or connection not found.');
         }
 
         $this->current = $connection;
@@ -195,8 +193,7 @@ class MasterSlaveReplication implements ReplicationInterface
      */
     protected function pickSlave()
     {
-        $slave = $this->slaves[array_rand($this->slaves)];
-        return $slave;
+        return $this->slaves[array_rand($this->slaves)];
     }
 
     /**
@@ -261,7 +258,7 @@ class MasterSlaveReplication implements ReplicationInterface
             $result = $connection->executeCommand($command);
         }
         catch(ConnectionException $e){
-             //Only switch to other read-slave if current connection is not master and there is more than 1 read-slave available
+            //Only switch to other read-slave if current connection is not master and there is more than 1 read-slave available
             if($connection != $this->master && count($this->slaves) > 1){
                 foreach($this->slaves as $slave){
                     if($slave == $connection){


### PR DESCRIPTION
We are using a Master-Slave Redis server. 
The availability of the master is handled on the server side (i.e. a read-slave is promoted to master).
However, if one of the read-slave is not reachable, the error handling on the server side is not quick enough. The read-slave gets replaced, but it can take up to 15 min until it works again.
During those 15 min, 1 out of n read-requests will fail (where n is the number of slaves).  To avoid this we modified the MasterSlaveReplication::executeCommand() method a little bit by adding a catch block for the ConnectionException. If it is thrown, the command is resent to one of the other available slaves.