### PR TITLE
Fail loudly if connection initialization fails

### DIFF
--- a/src/Connection/PhpiredisSocketConnection.php
+++ b/src/Connection/PhpiredisSocketConnection.php
@@ -15,6 +15,8 @@ use Predis\Command\CommandInterface;
 use Predis\NotSupportedException;
 use Predis\Response\Error as ErrorResponse;
 use Predis\Response\Status as StatusResponse;
+use Predis\Response\ErrorInterface as ErrorResponseInterface;
+use Predis\Response\ResponseInterface;
 
 /**
  * This class provides the implementation of a Predis connection that uses the
@@ -308,7 +310,10 @@ class PhpiredisSocketConnection extends AbstractConnection
     {
         if (parent::connect() && $this->initCommands) {
             foreach ($this->initCommands as $command) {
-                $this->executeCommand($command);
+                $response = $this->executeCommand($command);
+                if ($response instanceof ResponseInterface && $response instanceof ErrorResponseInterface) {
+                    $this->onConnectionError($command->parseResponse($response), 0);
+                }
             }
         }
     }

--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -160,10 +160,8 @@ class StreamConnection extends AbstractConnection
         if (parent::connect() && $this->initCommands) {
             foreach ($this->initCommands as $command) {
                 $response = $this->executeCommand($command);
-                if ($response instanceof ResponseInterface) {
-                    if ($response instanceof ErrorResponseInterface) {
-                        $this->onConnectionError($command->parseResponse($response), 0);
-                    }
+                if ($response instanceof ResponseInterface && $response instanceof ErrorResponseInterface) {
+                    $this->onConnectionError($command->parseResponse($response), 0);
                 }
             }
         }

--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -14,6 +14,8 @@ namespace Predis\Connection;
 use Predis\Command\CommandInterface;
 use Predis\Response\Error as ErrorResponse;
 use Predis\Response\Status as StatusResponse;
+use Predis\Response\ErrorInterface as ErrorResponseInterface;
+use Predis\Response\ResponseInterface;
 
 /**
  * Standard connection to Redis servers implemented on top of PHP's streams.
@@ -157,7 +159,12 @@ class StreamConnection extends AbstractConnection
     {
         if (parent::connect() && $this->initCommands) {
             foreach ($this->initCommands as $command) {
-                $this->executeCommand($command);
+                $response = $this->executeCommand($command);
+                if ($response instanceof ResponseInterface) {
+                    if ($response instanceof ErrorResponseInterface) {
+                        $this->onConnectionError($command->parseResponse($response), 0);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Right now if the `SELECT x` call fails for any reason, the process will continue on the wrong database. I don't know why this would happen, but we have some data in the db 0 that should not be there, so all I can think of is that sometimes it silently fails to switch DB.