### PR TITLE
Fix namespace typo in StreamConnection.php

### DIFF
--- a/src/Connection/StreamConnection.php
+++ b/src/Connection/StreamConnection.php
@@ -123,7 +123,7 @@ class StreamConnection extends AbstractConnection
     protected function unixStreamInitializer(ParametersInterface $parameters)
     {
         if (!isset($parameters->path)) {
-            throw new InvalidArgumentException('Missing UNIX domain socket path.');
+            throw new \InvalidArgumentException('Missing UNIX domain socket path.');
         }
 
         $uri = "unix://{$parameters->path}";


### PR DESCRIPTION
I think that there is typo in exception class namespace. Should be `new \InvalidArgumentException` instead of `new InvalidArgumentException`.