### PR TITLE
Make numeric field names work with HashKey iterator

### DIFF
--- a/src/Collection/Iterator/HashKey.php
+++ b/src/Collection/Iterator/HashKey.php
@@ -51,6 +51,7 @@ class HashKey extends CursorBasedIterator
     protected function extractNext()
     {
         $this->position = key($this->elements);
-        $this->current = array_shift($this->elements);
+        $this->current = $this->position === null ? null : $this->elements[$this->position];
+        unset($this->elements[$this->position]);
     }
 }


### PR DESCRIPTION
`array_shift` reindexes arrays that have only numeric keys. This causes all keys after the first to be incorrect when retrieving (parts of) a hash that contains only numeric keys.

This pull request replaces `array_shift` with a manual `unset`.