### PR TITLE
added zrevrangebylex in the list of available methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ package.xml
 composer.lock
 experiments/
 vendor/
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package.xml
 composer.lock
 experiments/
 vendor/
+.idea/

--- a/src/ClientContextInterface.php
+++ b/src/ClientContextInterface.php
@@ -121,6 +121,7 @@ use Predis\Command\CommandInterface;
  * @method $this zscore($key, $member)
  * @method $this zscan($key, $cursor, array $options = null)
  * @method $this zrangebylex($key, $start, $stop, array $options = null)
+ * @method $this zrevrangebylex($key, $start, $stop, array $options = null)
  * @method $this zremrangebylex($key, $min, $max)
  * @method $this zlexcount($key, $min, $max)
  * @method $this pfadd($key, array $elements)

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -129,6 +129,7 @@ use Predis\Profile\ProfileInterface;
  * @method string zscore($key, $member)
  * @method array  zscan($key, $cursor, array $options = null)
  * @method array  zrangebylex($key, $start, $stop, array $options = null)
+ * @method array  zrevrangebylex($key, $start, $stop, array $options = null)
  * @method int    zremrangebylex($key, $min, $max)
  * @method int    zlexcount($key, $min, $max)
  * @method int    pfadd($key, array $elements)

--- a/src/Command/ZSetReverseRangeByLex.php
+++ b/src/Command/ZSetReverseRangeByLex.php
@@ -11,6 +11,11 @@
 
 namespace Predis\Command;
 
+/**
+ * @link http://redis.io/commands/zrevrangebylex
+ *
+ * @author Daniele Alessandri <suppakilla@gmail.com>
+ */
 class ZSetReverseRangeByLex extends ZSetRangeByLex
 {
     /**


### PR DESCRIPTION
Hi,

I've noticed that ZREVRANGEBYLEX method was missing from the list of available methods so I've added it.

Also I've added link to the official redis docs for that method.

Ante.