### PR TITLE
Don't send AUTH and/or SELECT command after connecting to sentinels

### DIFF
--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -239,9 +239,10 @@ class SentinelReplication implements ReplicationInterface
         }
 
         if (is_array($parameters)) {
-            // We unset "password" and "database" from user-supplied parameters
-            // as they are not needed when connecting to sentinels.
-            unset($parameters['database'], $parameters['password']);
+            // We explicitly set "database" and "password" to null,
+            // so that no AUTH and SELECT command is send to the sentinels.
+            $parameters['database'] = null;
+            $parameters['password'] = null;
 
             if (!isset($parameters['timeout'])) {
                 $parameters['timeout'] = $this->sentinelTimeout;

--- a/tests/Predis/Connection/Replication/SentinelReplicationTest.php
+++ b/tests/Predis/Connection/Replication/SentinelReplicationTest.php
@@ -44,8 +44,7 @@ class SentinelReplicationTest extends PredisTestCase
 
         $parameters = $replication->getSentinelConnection()->getParameters()->toArray();
 
-        $this->assertArrayNotHasKey('password', $parameters);
-        $this->assertArrayNotHasKey('database', $parameters);
+        $this->assertArraySubset(array('database' => null, 'password' => null), $parameters);
     }
 
     /**


### PR DESCRIPTION
Connecting to sentinels is broken with v1.1. Bad commit: https://github.com/nrk/predis/commit/5a0dfc36020970d5ab5f58474b01797515df49ea#diff-e55f11b907debe0b57a114d0c38dc563R244.

AUTH and/or SELECT commands are sent to sentinels when password or database is specified. Sentinels don't understand these commands and thus master discovery fails and a Predis\ClientException with message "No sentinel server available for autodiscovery." is thrown.

We need to explicitly specify a null password and database.