### PR TITLE
Fallback redis role discovery for versions older than 2.8.12

### DIFF
--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -543,9 +543,9 @@ class SentinelReplication implements ReplicationInterface
             $info = $connection->executeCommand(RawCommand::create('INFO'));
             preg_match('#role:([a-zA-Z]+)#m', $info, $matches);
             if (! empty($matches)) {
-                $actualRole = [$matches[1]];
+                $actualRole = array($matches[1]);
             } else {
-                $actualRole = [''];
+                $actualRole = array('');
             }
         }
         if ($role !== $actualRole[0]) {

--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -539,7 +539,7 @@ class SentinelReplication implements ReplicationInterface
         $role = strtolower($role);
         $actualRole = $connection->executeCommand(RawCommand::create('ROLE'));
         if ($actualRole instanceof ErrorResponseInterface) {
-            $info = $connection->executeCommand(RawCommand::create('INFO REPLICATION'));
+            $info = $connection->executeCommand(RawCommand::create('INFO', 'REPLICATION'));
             preg_match('/role:([a-zA-Z]+)/i', $info, $matches);
             if (! empty($matches)) {
                 $actualRole = array($matches[1]);

--- a/src/Connection/Replication/SentinelReplication.php
+++ b/src/Connection/Replication/SentinelReplication.php
@@ -20,7 +20,6 @@ use Predis\Connection\NodeConnectionInterface;
 use Predis\Connection\Parameters;
 use Predis\Replication\ReplicationStrategy;
 use Predis\Replication\RoleException;
-use Predis\Response\Error;
 use Predis\Response\ErrorInterface as ErrorResponseInterface;
 use Predis\Response\ServerException;
 
@@ -539,9 +538,9 @@ class SentinelReplication implements ReplicationInterface
     {
         $role = strtolower($role);
         $actualRole = $connection->executeCommand(RawCommand::create('ROLE'));
-        if (is_object($actualRole) && $actualRole instanceof Error) {
-            $info = $connection->executeCommand(RawCommand::create('INFO'));
-            preg_match('#role:([a-zA-Z]+)#m', $info, $matches);
+        if ($actualRole instanceof ErrorResponseInterface) {
+            $info = $connection->executeCommand(RawCommand::create('INFO REPLICATION'));
+            preg_match('/role:([a-zA-Z]+)/i', $info, $matches);
             if (! empty($matches)) {
                 $actualRole = array($matches[1]);
             } else {

--- a/tests/Predis/Connection/Replication/SentinelReplicationTest.php
+++ b/tests/Predis/Connection/Replication/SentinelReplicationTest.php
@@ -1072,7 +1072,7 @@ class SentinelReplicationTest extends PredisTestCase
         $master
             ->expects($this->at(4))
             ->method('executeCommand')
-            ->with($this->isRedisCommand('INFO', ['REPLICATION']))
+            ->with($this->isRedisCommand('INFO', array('REPLICATION')))
             ->will($this->returnValue($replicationInfo));
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
         

--- a/tests/Predis/Connection/Replication/SentinelReplicationTest.php
+++ b/tests/Predis/Connection/Replication/SentinelReplicationTest.php
@@ -1072,7 +1072,7 @@ class SentinelReplicationTest extends PredisTestCase
         $master
             ->expects($this->at(4))
             ->method('executeCommand')
-            ->with($this->isRedisCommand('INFO REPLICATION'))
+            ->with($this->isRedisCommand('INFO', ['REPLICATION']))
             ->will($this->returnValue($replicationInfo));
         $replication = $this->getReplicationConnection('svc', array($sentinel1));
         


### PR DESCRIPTION
Predis version: last stable
Redis server version: 2.8.4
PHP version: both 5.6 and 7 (we're just migrating)

@nrk :
When trying to implement Predis on our production environment (with sentinel distribution), we noticed that it failed trying to acquire a connection. Basically, it fails trying to use an error (command not found) as an array ($actualRole[0])

The reason was  that SentinelReplication::assertConnectionRole uses the command ROLE to obtain the server role status. This command was introduced on redis 2.8.12 (http://redis.io/commands/role), and the code doesn't check the return type of executeCommand (just assumes that it's gonna return an array).

We're planning to migrate our redis servers to a newer version, but this takes time on production environment, and the fix is quite easy (just check the output of executeCommand and do a fallback to the info command).

We've been using this fork on production for a month now, without any issue (and predis works great, thanks!)
