### PR TITLE
Fix sentinel getClientFor cannot use index

### DIFF
--- a/src/Connection/Aggregate/SentinelReplication.php
+++ b/src/Connection/Aggregate/SentinelReplication.php
@@ -556,8 +556,11 @@ class SentinelReplication implements ReplicationInterface
 
         $this->getSlaves();
 
-        if (isset($this->slaves[$connectionId])) {
-            return $this->slaves[$connectionId];
+        // fixed $connectionId is an index
+        $slaves = is_numeric($connectionId) ? array_values($this->slaves) : $this->slaves;
+
+        if (isset($slaves[$connectionId])) {
+            return $slaves[$connectionId];
         }
     }
 

--- a/tests/Predis/Connection/Aggregate/SentinelReplicationTest.php
+++ b/tests/Predis/Connection/Aggregate/SentinelReplicationTest.php
@@ -129,6 +129,8 @@ class SentinelReplicationTest extends PredisTestCase
         $this->assertSame($master, $replication->getConnectionById('master'));
         $this->assertSame($slave1, $replication->getConnectionById('slave1'));
         $this->assertSame($slave2, $replication->getConnectionById('slave2'));
+        $this->assertSame($slave1, $replication->getConnectionById(0));
+        $this->assertSame($slave2, $replication->getConnectionById(1));
 
         $this->assertSame($master, $replication->getMaster());
         $this->assertSame(array($slave1, $slave2), $replication->getSlaves());
@@ -658,6 +660,7 @@ class SentinelReplicationTest extends PredisTestCase
 
         $this->assertSame($master, $replication->getConnectionById('master'));
         $this->assertSame($slave1, $replication->getConnectionById('slave1'));
+        $this->assertSame($slave1, $replication->getConnectionById(0));
         $this->assertNull($replication->getConnectionById('unknown'));
     }
 
@@ -1218,6 +1221,8 @@ class SentinelReplicationTest extends PredisTestCase
         $this->assertEquals($master, $unserialized->getConnectionById('master'));
         $this->assertEquals($slave1, $unserialized->getConnectionById('slave1'));
         $this->assertEquals($master, $unserialized->getConnectionById('slave2'));
+        $this->assertEquals($slave1, $unserialized->getConnectionById(0));
+        $this->assertEquals($master, $unserialized->getConnectionById(1));
         $this->assertEquals($strategy, $unserialized->getReplicationStrategy());
     }
 


### PR DESCRIPTION
In version 1.1.1

``` php
$client = new Predis\Client([
    'tcp://127.0.0.1:26379',
    'tcp://127.0.0.1:26380',
    'tcp://127.0.0.1:26381',
], [
    'replication' => 'sentinel',
    'service' => 'redis_service',
]);

$slave1 = $client->getClientFor(0);
```

Throw 'InvalidArgumentException' with message 'Invalid connection ID: 0.'
