### PR TITLE
Check socket state using feof() in isConnected() method

### DIFF
--- a/src/Connection/AbstractConnection.php
+++ b/src/Connection/AbstractConnection.php
@@ -69,7 +69,7 @@ abstract class AbstractConnection implements NodeConnectionInterface
      */
     public function isConnected()
     {
-        return isset($this->resource);
+        return isset($this->resource) && !feof($this->resource);
     }
 
     /**
@@ -150,7 +150,7 @@ abstract class AbstractConnection implements NodeConnectionInterface
      */
     public function getResource()
     {
-        if (isset($this->resource)) {
+        if ($this->isConnected()) {
             return $this->resource;
         }
 


### PR DESCRIPTION
## What?
In order to check whether client is connected to the server, don't only check `isset($this->resource)`, but also `!feof($this->resource)` to make sure the server didn't close the connection.

## Why?
If Redis server closes connection, current implementation of `isConnected()` won't detect it.