### PR TITLE
PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 branches:
   except:

--- a/tests/Predis/Command/RawCommandTest.php
+++ b/tests/Predis/Command/RawCommandTest.php
@@ -74,10 +74,27 @@ class RawCommandTest extends PredisTestCase
      * argument is missing, PHP emits an E_WARNING.
      *
      * @group disconnected
-     * @expectedException \PHPUnit_Framework_Error_Warning
      */
     public function testPHPWarningOnMissingCommandIDWithStaticCreate()
     {
+        if (version_compare(PHP_VERSION, "7.1", '>')) {
+            $this->markTestSkipped('only for PHP < 7.1');
+        }
+        $this->setExpectedException('PHPUnit_Framework_Error_Warning');
+        RawCommand::create();
+    }
+
+    /**
+     * The signature of RawCommand::create() requires one argument which is the
+     * ID of the command (other arguments are fetched dinamically). If the first
+     * argument is missing, PHP 7.1 throw an exception
+     *
+     * @requires PHP 7.1
+     * @group disconnected
+     */
+    public function testPHPWarningOnMissingCommandIDWithStaticCreate71()
+    {
+        $this->setExpectedException('ArgumentCountError');
         RawCommand::create();
     }
 


### PR DESCRIPTION
Discovered in Fedora QA since PHP 7.1.0RC6
https://apps.fedoraproject.org/koschei/package/php-nrk-Predis?collection=f26

So 1 commit to enable 7.1 on travis, 1 to fix the failing test.