### PR TITLE
Stop treating empty strings as valid parameters

### DIFF
--- a/src/Connection/Factory.php
+++ b/src/Connection/Factory.php
@@ -173,13 +173,13 @@ class Factory implements FactoryInterface
     {
         $parameters = $connection->getParameters();
 
-        if (isset($parameters->password)) {
+        if (!empty($parameters->password)) {
             $connection->addConnectCommand(
                 new RawCommand('AUTH', array($parameters->password))
             );
         }
 
-        if (isset($parameters->database)) {
+        if (!empty($parameters->database)) {
             $connection->addConnectCommand(
                 new RawCommand('SELECT', array($parameters->database))
             );


### PR DESCRIPTION
Ideally, these parameters would always be `null` but may end up as empty strings `''` and then invalid `AUTH` commands will be sent.