### PR TITLE
fix typo in tests/README.md at branch v2.0-wait-abstraction

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -65,7 +65,7 @@ $ phpunit --exclude-group slow
 ### Testing Redis commands ###
 
 We also provide an helper script in the `bin` directory that can be used to automatically generate a
-file with the scheleton of a test case to test a Redis command by specifying the name of the class
+file with the skeleton of a test case to test a Redis command by specifying the name of the class
 in the `Predis\Command\Redis` namespace (only classes in this namespace are considered valid).
 For example to generate a test case for `SET` (represented by the `Predis\Command\Redis\StringSet`
 class):


### PR DESCRIPTION
Fixes typo `scheleton` -> `skeleton` in v2.0-wait-abstraction branch.
