### PR TITLE
fix typo in tests/README.md at v1.0 branch

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -69,7 +69,7 @@ $ phpunit --exclude-group slow
 ### Testing Redis commands ###
 
 We also provide an helper script in the `bin` directory that can be used to automatically generate a
-file with the scheleton of a test case to test a Redis command by specifying the name of the class
+file with the skeleton of a test case to test a Redis command by specifying the name of the class
 in the `Predis\Command` namespace (only classes in this namespace are considered valid). For example
  to generate a test case for `SET` (represented by the `Predis\Command\StringSet` class):
 


### PR DESCRIPTION
Fixes typo at v1.0 branch: scheleton -> skeleton
