### PR TITLE
Fix each

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 branches:
   except:
     - v0.5
@@ -22,3 +21,6 @@ script:
   - vendor/bin/phpunit -c phpunit.xml.travisci
 matrix:
   fast_finish: true
+  include:
+    - php: hhvm
+      dist: trusty

--- a/src/Collection/Iterator/HashKey.php
+++ b/src/Collection/Iterator/HashKey.php
@@ -50,11 +50,11 @@ class HashKey extends CursorBasedIterator
      */
     protected function extractNext()
     {
-        if ($kv = each($this->elements)) {
-            $this->position = $kv[0];
-            $this->current = $kv[1];
-
+        foreach ($this->elements as $k => $v) {
+            $this->position = $k;
+            $this->current = $v;
             unset($this->elements[$this->position]);
+            break;
         }
     }
 }

--- a/src/Collection/Iterator/SortedSetKey.php
+++ b/src/Collection/Iterator/SortedSetKey.php
@@ -50,11 +50,11 @@ class SortedSetKey extends CursorBasedIterator
      */
     protected function extractNext()
     {
-        if ($kv = each($this->elements)) {
-            $this->position = $kv[0];
-            $this->current = $kv[1];
-
+        foreach ($this->elements as $k => $v) {
+            $this->position = $k;
+            $this->current = $v;
             unset($this->elements[$this->position]);
+            break;
         }
     }
 }


### PR DESCRIPTION
When running in the environment of php 7.2, the following warning was issued.
`The each() function is deprecated. This message will be suppressed on further calls: 1x`

`each()` function seems to be deprecated in 7.2.
http://php.net/manual/en/function.each.php

I tried to fix it, please merge if necessary.