### PR TITLE
Update CRC16.php

### DIFF
--- a/src/Cluster/Hash/CRC16.php
+++ b/src/Cluster/Hash/CRC16.php
@@ -64,7 +64,7 @@ class CRC16 implements HashGeneratorInterface
         $strlen = strlen($value);
 
         for ($i = 0; $i < $strlen; ++$i) {
-            $crc = (($crc << 8) ^ $CCITT_16[($crc >> 8) ^ ord($value[$i])]) & 0xFFFF;
+            $crc = (($crc << 8) ^ $CCITT_16[($crc >> 8) ^ ord(substr($value, $i, 1))]) & 0xFFFF;
         }
 
         return $crc;


### PR DESCRIPTION
Hello, I think i have meet a bug when use redis cluster. 
if the redis key is a number, this function always return 0. it will cause an error when use redis cluster. i think this is a bug need repair