### PR TITLE
fix `AUTH` failed: ERR Client sent AUTH, but no password is set

### DIFF
--- a/src/Connection/Factory.php
+++ b/src/Connection/Factory.php
@@ -173,7 +173,7 @@ class Factory implements FactoryInterface
     {
         $parameters = $connection->getParameters();
 
-        if (isset($parameters->password)) {
+        if (empty($parameters->password)) {
             $connection->addConnectCommand(
                 new RawCommand(array('AUTH', $parameters->password))
             );

--- a/src/Connection/Factory.php
+++ b/src/Connection/Factory.php
@@ -173,7 +173,7 @@ class Factory implements FactoryInterface
     {
         $parameters = $connection->getParameters();
 
-        if (empty($parameters->password)) {
+        if (!empty($parameters->password)) {
             $connection->addConnectCommand(
                 new RawCommand(array('AUTH', $parameters->password))
             );


### PR DESCRIPTION
for example:
in laravel or other projects  .env file

```
REDIS_HOST=redis
REDIS_PASSWORD=
REDIS_PORT=6379
```