### PR TITLE
Fix issues when using setlocale

### DIFF
--- a/src/Profile/RedisProfile.php
+++ b/src/Profile/RedisProfile.php
@@ -45,7 +45,7 @@ abstract class RedisProfile implements ProfileInterface
      */
     public function supportsCommand($commandID)
     {
-        return isset($this->commands[strtoupper($commandID)]);
+        return isset($this->commands[mb_strtoupper($commandID)]);
     }
 
     /**
@@ -72,7 +72,7 @@ abstract class RedisProfile implements ProfileInterface
      */
     public function getCommandClass($commandID)
     {
-        if (isset($this->commands[$commandID = strtoupper($commandID)])) {
+        if (isset($this->commands[$commandID = mb_strtoupper($commandID)])) {
             return $this->commands[$commandID];
         }
     }
@@ -82,7 +82,7 @@ abstract class RedisProfile implements ProfileInterface
      */
     public function createCommand($commandID, array $arguments = array())
     {
-        $commandID = strtoupper($commandID);
+        $commandID = mb_strtoupper($commandID);
 
         if (!isset($this->commands[$commandID])) {
             throw new ClientException("Command '$commandID' is not a registered Redis command.");
@@ -115,7 +115,7 @@ abstract class RedisProfile implements ProfileInterface
             throw new \InvalidArgumentException("The class '$class' is not a valid command class.");
         }
 
-        $this->commands[strtoupper($commandID)] = $class;
+        $this->commands[mb_strtoupper($commandID)] = $class;
     }
 
     /**


### PR DESCRIPTION
If you set the locale to Turkish before running $redis->expire(...) you
will get this error:
Command 'EXPÝRE' is not a registered Redis command.

This is because strtoupper capitalizes expire to EXPÝRE. mb_strtoupper
dosen't use the locale, so it doesn't have this problem.

Here's an example. You need to have the Turkish locale installed on your system for this to show the bug:
```
setlocale(LC_ALL, 'tr_TR');
print(strtoupper('expire') . "\n");
```

