### PR TITLE
Fixed wrong annotation for spop method.

### DIFF
--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -107,7 +107,7 @@ use Predis\Profile\ProfileInterface;
  * @method int    sismember($key, $member)
  * @method array  smembers($key)
  * @method int    smove($source, $destination, $member)
- * @method string spop($key, $count = null)
+ * @method array spop($key, $count = null)
  * @method string srandmember($key, $count = null)
  * @method int    srem($key, $member)
  * @method array  sscan($key, $cursor, array $options = null)


### PR DESCRIPTION
Wrong annotation for method spop in ClientInterface. Annotation says it returns string, but it returns array.