### PR TITLE
Add new command: ZPOPMAX (Redis 5.0)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -38,7 +38,7 @@
 
     <php>
         <!-- Redis -->
-        <const name="REDIS_SERVER_VERSION" value="3.2" />
+        <const name="REDIS_SERVER_VERSION" value="5.0" />
         <const name="REDIS_SERVER_HOST" value="127.0.0.1" />
         <const name="REDIS_SERVER_PORT" value="6379" />
         <const name="REDIS_SERVER_DBNUM" value="15" />

--- a/src/ClientContextInterface.php
+++ b/src/ClientContextInterface.php
@@ -163,6 +163,7 @@ use Predis\Command\CommandInterface;
  * @method $this geodist($key, $member1, $member2, $unit = null)
  * @method $this georadius($key, $longitude, $latitude, $radius, $unit, array $options = null)
  * @method $this georadiusbymember($key, $member, $radius, $unit, array $options = null)
+ * @method $this zpopmax($key)
  *
  * @author Daniele Alessandri <suppakilla@gmail.com>
  */

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -171,6 +171,7 @@ use Predis\Profile\ProfileInterface;
  * @method string geodist($key, $member1, $member2, $unit = null)
  * @method array  georadius($key, $longitude, $latitude, $radius, $unit, array $options = null)
  * @method array  georadiusbymember($key, $member, $radius, $unit, array $options = null)
+ * @method array  zpopmax()
  *
  * @author Daniele Alessandri <suppakilla@gmail.com>
  */

--- a/src/Command/Processor/KeyPrefixProcessor.php
+++ b/src/Command/Processor/KeyPrefixProcessor.php
@@ -166,6 +166,8 @@ class KeyPrefixProcessor implements ProcessorInterface
             'GEODIST' => 'static::first',
             'GEORADIUS' => 'static::georadius',
             'GEORADIUSBYMEMBER' => 'static::georadius',
+            /* ---------------- Redis 5.0.0 ---------------- */
+            'ZPOPMAX' => 'static::first'
         );
     }
 

--- a/src/Command/ZSetRemoveMaxByScore.php
+++ b/src/Command/ZSetRemoveMaxByScore.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) Daniele Alessandri <suppakilla@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command;
+
+/**
+ * Class ZSetRemoveMaxByScore
+ * @package Predis\Command
+ *
+ * @link https://redis.io/commands/zpopmax
+ *
+ * @author Ahmed Raafat <ahmed.raafat1412@gmail.com>
+ */
+class ZSetRemoveMaxByScore extends Command
+{
+    /**
+     * @inheritDoc
+     */
+    public function getId()
+    {
+        return 'ZPOPMAX';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function parseResponse($data)
+    {
+        $response = array();
+
+        $responseCount = count($data);
+        for ($i = 0; $i < $responseCount; $i++) {
+            $response[$data[$i]] = $data[++$i];
+        }
+
+        return $response;
+    }
+}

--- a/src/Profile/Factory.php
+++ b/src/Profile/Factory.php
@@ -30,7 +30,7 @@ final class Factory
         '3.2' => 'Predis\Profile\RedisVersion320',
         '5.0' => 'Predis\Profile\RedisVersion500',
         'dev' => 'Predis\Profile\RedisUnstable',
-        'default' => 'Predis\Profile\RedisVersion320',
+        'default' => 'Predis\Profile\RedisVersion500',
     );
 
     /**

--- a/src/Profile/Factory.php
+++ b/src/Profile/Factory.php
@@ -28,6 +28,7 @@ final class Factory
         '2.8' => 'Predis\Profile\RedisVersion280',
         '3.0' => 'Predis\Profile\RedisVersion300',
         '3.2' => 'Predis\Profile\RedisVersion320',
+        '5.0' => 'Predis\Profile\RedisVersion500',
         'dev' => 'Predis\Profile\RedisUnstable',
         'default' => 'Predis\Profile\RedisVersion320',
     );

--- a/src/Profile/RedisVersion320.php
+++ b/src/Profile/RedisVersion320.php
@@ -276,6 +276,11 @@ class RedisVersion320 extends RedisProfile
             'GEODIST' => 'Predis\Command\GeospatialGeoDist',
             'GEORADIUS' => 'Predis\Command\GeospatialGeoRadius',
             'GEORADIUSBYMEMBER' => 'Predis\Command\GeospatialGeoRadiusByMember',
+
+            /* ---------------- Redis 5.0 ---------------- */
+
+            /* commands operating on sorted sets */
+            'ZPOPMAX' => 'Predis\Command\ZSetRemoveMaxByScore',
         );
     }
 }

--- a/src/Profile/RedisVersion500.php
+++ b/src/Profile/RedisVersion500.php
@@ -1,35 +1,24 @@
 <?php
 
-/*
- * This file is part of the Predis package.
- *
- * (c) Daniele Alessandri <suppakilla@gmail.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
 
 namespace Predis\Profile;
 
-/**
- * Server profile for Redis 3.0.
- *
- * @author Daniele Alessandri <suppakilla@gmail.com>
- */
-class RedisVersion320 extends RedisProfile
+
+class RedisVersion500 extends RedisProfile
 {
+
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getVersion()
     {
-        return '3.2';
+        return '5.0';
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
-    public function getSupportedCommands()
+    protected function getSupportedCommands()
     {
         return array(
             /* ---------------- Redis 1.2 ---------------- */
@@ -276,6 +265,11 @@ class RedisVersion320 extends RedisProfile
             'GEODIST' => 'Predis\Command\GeospatialGeoDist',
             'GEORADIUS' => 'Predis\Command\GeospatialGeoRadius',
             'GEORADIUSBYMEMBER' => 'Predis\Command\GeospatialGeoRadiusByMember',
+
+            /* ---------------- Redis 5.0 ---------------- */
+
+            /* commands operating on sorted sets */
+            'ZPOPMAX' => 'Predis\Command\ZSetRemoveMaxByScore',
         );
     }
 }

--- a/tests/Predis/Command/ZSetRemoveMaxByScoreTest.php
+++ b/tests/Predis/Command/ZSetRemoveMaxByScoreTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Predis package.
+ *
+ * (c) Daniele Alessandri <suppakilla@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Predis\Command;
+
+/**
+ * Class ZSetRemoveMaxByScoreTest
+ * @package Predis\Command
+ * @author Ahmed Raafat <ahmed.raafat1412@gmail.com>
+ *
+ * @group commands
+ * @group realm-zset
+ */
+class ZSetRemoveMaxByScoreTest extends PredisCommandTestCase
+{
+    /**
+     * @inheritDoc
+     */
+    protected function getExpectedCommand()
+    {
+        return 'Predis\Command\ZSetRemoveMaxByScore';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getExpectedId()
+    {
+        return 'ZPOPMAX';
+    }
+
+    /**
+     * @group disconnected
+     */
+    public function testParseResponse()
+    {
+        $data = array('four', '4', 'three', '3');
+        $expectedResponse = array('four' => '4', 'three' => '3');
+        $this->assertSame($expectedResponse, $this->getCommand()->parseResponse($data));
+    }
+
+    /**
+     * @group connected
+     */
+    public function testDefaultPopAndReturnMaxHighestScoreMembers()
+    {
+        $redisClient = $this->getClient();
+
+        $values = array(
+            'one' => 1,
+            'two' => 2,
+            'three' => 3,
+            'four' => 4,
+        );
+
+        $redisClient->zadd('mytestzset', $values);
+
+        $expectedResponse = array('four' => '4');
+
+        $this->assertSame($expectedResponse, $redisClient->zpopmax('mytestzset'));
+    }
+
+    /**
+     * @group connected
+     */
+    public function testPopAndReturnMaxHighestScoreMembersWithCount()
+    {
+        $redisClient = $this->getClient();
+
+        $values = array(
+            'one' => 1,
+            'two' => 2,
+            'three' => 3,
+            'four' => 4,
+        );
+        $count = 2;
+
+        $redisClient->zadd('mytestzset', $values);
+
+        $expectedResponse = array('four' => '4', 'three' => '3');
+
+        $this->assertSame($expectedResponse, $redisClient->zpopmax('mytestzset', $count));
+    }
+
+    /**
+     * @group connected
+     */
+    public function testPopAndReturnMaxHighestScoreMembersWithEmptyZSet()
+    {
+        $redisClient = $this->getClient();
+
+        $redisClient->zadd('mytestzset', ['one' => 1]);
+
+        $redisClient->zpopmax('mytestzset');
+
+        $this->assertSame([], $redisClient->zpopmax('mytestzset'));
+    }
+}

--- a/tests/Predis/Profile/RedisUnstableTest.php
+++ b/tests/Predis/Profile/RedisUnstableTest.php
@@ -197,6 +197,7 @@ class RedisUnstableTest extends PredisProfileTestCase
             156 => 'GEODIST',
             157 => 'GEORADIUS',
             158 => 'GEORADIUSBYMEMBER',
+            159 => 'ZPOPMAX',
         );
     }
 }

--- a/tests/Predis/Profile/RedisVersion320Test.php
+++ b/tests/Predis/Profile/RedisVersion320Test.php
@@ -197,6 +197,7 @@ class RedisVersion320Test extends PredisProfileTestCase
             156 => 'GEODIST',
             157 => 'GEORADIUS',
             158 => 'GEORADIUSBYMEMBER',
+            159 => 'ZPOPMAX',
         );
     }
 }


### PR DESCRIPTION
Added [**ZPOPMAX command**](https://redis.io/commands/zpopmax).

Related to issue #592

Example of usgae:
```php
$client = new \Predis\Client('tcp://127.0.0.1:6379', array('profile' => '5.0'));

$values = array(
    'one' => 1,
    'two' => 2,
    'three' => 3,
    'four' => 4,
);

$client->zadd('myzset', $values);

# $popedValues = $client->zpopmax('myzset');
# With count specified
$count = 2;
$popedValues = $client->zpopmax('myzset', $count);

print_r($popedValue);
```